### PR TITLE
Fixing phrases page

### DIFF
--- a/app/assets/stylesheets/translate_page.css
+++ b/app/assets/stylesheets/translate_page.css
@@ -6,8 +6,17 @@
 #passage_text {
   color: #888;
 }
+
 #translator_image{
   margin-left:auto;
-margin-right:auto;
-width: 70%;
+  margin-right:auto;
+  width: 70%;
+}
+
+.faded_text {
+  color: #999;
+}
+
+.well {
+  overflow: hidden;
 }

--- a/app/controllers/phrases_controller.rb
+++ b/app/controllers/phrases_controller.rb
@@ -3,12 +3,12 @@ class PhrasesController < ApplicationController
   def index
     @phrases = Phrase.all
     @translations = Translation.robot_translations_hash(@phrases.pluck(:id))
-    @translations = Phrase.best_translations.each_with_object({}) do |trans, ret|
-      ret[trans.phrase_id] = trans.translation
+    @translations = Phrase.best_translations_for(@phrases.map(&:id)).each_with_object({}) do |trans, ret|
+      ret[trans.phrase_id] = TranslatedPhrase.new(trans.translation, trans.locale)
     end
 
     Phrase.find(Phrase.pluck(:id) - @translations.keys).each_with_object(@translations) do |phrase, ret|
-      ret[phrase.id] = phrase.key
+      ret[phrase.id] = TranslatedPhrase.new(phrase.key, "en")
     end
   end
 
@@ -27,3 +27,5 @@ class PhrasesController < ApplicationController
   end
 
 end
+
+TranslatedPhrase = Struct.new(:text, :locale)

--- a/app/views/phrases/index.html.erb
+++ b/app/views/phrases/index.html.erb
@@ -11,7 +11,7 @@
   </div>
 </div>
 
-<%= @phrases.each do |phrase| %>
+<% @phrases.each do |phrase| %>
   <div class="row">
 
     <div class="col-md-5 col-md-offset-1 col-sm-6">
@@ -19,8 +19,19 @@
     </div>
 
     <div class="col-md-5 col-sm-6">
-      <p><%= @translations[phrase.id] %></p>
+      <p>
+        <% if @translations[phrase.id].locale == "en" %>
+          <!-- lighter color -->
+          <a href="<%= phrase_path(phrase) %>">
+            <em><span class="faded_text"><%= @translations[phrase.id].text %></span></em>
+          </a>
+        <% else %>
+          <%= @translations[phrase.id].text %>
+        <% end %>
+      </p>
     </div>
   </div>
+
+  <hr />
 
 <% end %>


### PR DESCRIPTION
Should be working now :) If there's no current Chinese translation, the English text is displayed instead. Fixes #14.
