### PR TITLE
Fix best translations query

### DIFF
--- a/app/models/phrase.rb
+++ b/app/models/phrase.rb
@@ -1,4 +1,4 @@
-  class Phrase < ActiveRecord::Base
+class Phrase < ActiveRecord::Base
   has_many :translations
 
   # Returns the translation in each locale with the highest number of votes


### PR DESCRIPTION
This fixes the query that grabs the best (most highly voted) translation for a set of phrases. It broke when we switched to Postgres.
